### PR TITLE
Comedians show endpoint

### DIFF
--- a/app/controllers/api/v1/comedians_controller.rb
+++ b/app/controllers/api/v1/comedians_controller.rb
@@ -27,11 +27,23 @@ class Api::V1::ComediansController < ApplicationController
     render json: ComedianSerializer.new(comedian, include: [:tvspecials]) if comedian.save
   end
 
+  def show
+    comedian = Comedian.find(params[:id])
+    render json: ComedianSerializer.new(comedian, include: [:tvspecials])
+    rescue ActiveRecord::RecordNotFound
+        render json: cannot_find_comedian
+  end
+
   private
 
     def cannot_find_comedians
       response.status = 404
       response.body = 'Sorry, no comedians avaiable.'
+    end
+
+    def cannot_find_comedian
+      response.status = 404
+      response.body = 'Sorry, this comedian does not exist.'
     end
 
     def missing_attributes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/comedians', to: 'comedians#index'
+      get '/comedians/:id', to: 'comedians#show'
       post '/comedians', to: 'comedians#create'
     end
   end

--- a/spec/api/v1/comedians/show_spec.rb
+++ b/spec/api/v1/comedians/show_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe "Comeadian Show Page" do
+  it "recieves a get request for a single comedian" do
+    com1 = Comedian.create({
+      name: "Nate",
+      age: 35,
+      city: "Denver",
+      image_url: "https://i.ytimg.com/vi/zF1T9-6J4Hg/maxresdefault.jpg"
+      })
+
+    com2 = Comedian.create(
+      name: "J Dog",
+      age: 30,
+      city: "Arvada",
+      image_url: "https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcS_6JOIep3YiTWHQ4LyD0OcQoR5XJV7u31tgg&usqp=CAU"
+    )
+
+    get "/api/v1/comedians/#{com1.id}"
+
+    expect(response).to be_successful
+    expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
+    expect(response.body).to include(com1.name)
+    expect(response.body).to include(com1.city)
+    expect(response.body).not_to include(com2.name)
+    expect(response.body).not_to include(com2.city)
+  end
+
+  it "catches an invalid id" do
+
+    get '/api/v1/comedians/2'
+
+    expect(response.body).to eq('Sorry, this comedian does not exist.')
+    expect(response.status).to eq(404)
+    expect(response.headers["Content-Type"]).to eq("application/json; charset=utf-8")
+  end
+end


### PR DESCRIPTION
Create show endpoint for retuning a single comedian based on ID. 
Add sad path to render a 404 if a record cannot be found in databases for the ID.